### PR TITLE
Gainline - Adding season teams relationship.

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -7,6 +7,8 @@ http://localhost:8080
 
 curl http://localhost:8080/health
 
+http://localhost:8080/swagger/index.html#/
+
 ```
 docker run --rm -v $(pwd)/migrations:/migrations \
   --network gainline_default migrate/migrate \

--- a/api/db/db/models.go
+++ b/api/db/db/models.go
@@ -90,6 +90,15 @@ type Season struct {
 	DeletedAt     sql.NullTime
 }
 
+type SeasonTeam struct {
+	ID        uuid.UUID
+	SeasonID  uuid.UUID
+	TeamID    uuid.UUID
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt sql.NullTime
+}
+
 type Team struct {
 	ID           uuid.UUID
 	Name         string

--- a/api/db/db_handler/queries.go
+++ b/api/db/db_handler/queries.go
@@ -124,3 +124,27 @@ func DeleteTeam(
 ) error {
 	return q.DeleteTeam(ctx, params)
 }
+
+func CreateSeasonTeams(
+	ctx context.Context,
+	q Queries,
+	params db.CreateSeasonTeamsParams,
+) error {
+	return q.CreateSeasonTeams(ctx, params)
+}
+
+func GetSeasonTeams(
+	ctx context.Context,
+	q Queries,
+	seasonID uuid.UUID,
+) ([]db.GetSeasonTeamsRow, error) {
+	return q.GetSeasonTeams(ctx, seasonID)
+}
+
+func DeleteSeasonTeam(
+	ctx context.Context,
+	q Queries,
+	params db.DeleteSeasonTeamParams,
+) error {
+	return q.DeleteSeasonTeam(ctx, params)
+}

--- a/api/db/db_handler/wrapper.go
+++ b/api/db/db_handler/wrapper.go
@@ -42,6 +42,11 @@ type Queries interface {
 	GetTeams(ctx context.Context) ([]db.Team, error)
 	UpdateTeam(ctx context.Context, arg db.UpdateTeamParams) error
 	DeleteTeam(ctx context.Context, arg db.DeleteTeamParams) error
+
+	//SeasonTeams
+	CreateSeasonTeams(ctx context.Context, arg db.CreateSeasonTeamsParams) error
+	GetSeasonTeams(ctx context.Context, seasonID uuid.UUID) ([]db.GetSeasonTeamsRow, error)
+	DeleteSeasonTeam(ctx context.Context, arg db.DeleteSeasonTeamParams) error
 }
 
 type DBWrapper struct {

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -697,6 +697,12 @@ const docTemplate = `{
         "api.SeasonRequest": {
             "type": "object",
             "properties": {
+                "TeamIDs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "end_date": {
                     "type": "string"
                 },
@@ -731,6 +737,12 @@ const docTemplate = `{
                 },
                 "start_date": {
                     "type": "string"
+                },
+                "teams": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.TeamResponse"
+                    }
                 },
                 "updated_at": {
                     "type": "string"

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -689,6 +689,12 @@
         "api.SeasonRequest": {
             "type": "object",
             "properties": {
+                "TeamIDs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "end_date": {
                     "type": "string"
                 },
@@ -723,6 +729,12 @@
                 },
                 "start_date": {
                     "type": "string"
+                },
+                "teams": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.TeamResponse"
+                    }
                 },
                 "updated_at": {
                     "type": "string"

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -19,6 +19,10 @@ definitions:
     type: object
   api.SeasonRequest:
     properties:
+      TeamIDs:
+        items:
+          type: string
+        type: array
       end_date:
         type: string
       rounds:
@@ -42,6 +46,10 @@ definitions:
         type: integer
       start_date:
         type: string
+      teams:
+        items:
+          $ref: '#/definitions/api.TeamResponse'
+        type: array
       updated_at:
         type: string
     type: object

--- a/api/http/api/season.go
+++ b/api/http/api/season.go
@@ -3,37 +3,25 @@ package api
 import (
 	"time"
 
-	"github.com/bradley-adams/gainline/db/db"
 	"github.com/google/uuid"
 	"github.com/guregu/null/zero"
 )
 
 type SeasonRequest struct {
-	StartDate time.Time `json:"start_date"`
-	EndDate   time.Time `json:"end_date"`
-	Rounds    int32     `json:"rounds"`
+	StartDate time.Time   `json:"start_date"`
+	EndDate   time.Time   `json:"end_date"`
+	Rounds    int32       `json:"rounds"`
+	TeamIDs   []uuid.UUID `json:"TeamIDs"`
 }
 
 type SeasonResponse struct {
-	ID            uuid.UUID `json:"id"`
-	CompetitionID uuid.UUID `json:"competition_id"`
-	StartDate     time.Time `json:"start_date"`
-	EndDate       time.Time `json:"end_date"`
-	Rounds        int32     `json:"rounds"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
-	DeletedAt     zero.Time `json:"deleted_at"`
-}
-
-func ToSeasonResponse(s db.Season) SeasonResponse {
-	return SeasonResponse{
-		ID:            s.ID,
-		CompetitionID: s.CompetitionID,
-		StartDate:     s.StartDate,
-		EndDate:       s.EndDate,
-		Rounds:        s.Rounds,
-		CreatedAt:     s.CreatedAt,
-		UpdatedAt:     s.UpdatedAt,
-		DeletedAt:     zero.TimeFrom(s.DeletedAt.Time),
-	}
+	ID            uuid.UUID      `json:"id"`
+	CompetitionID uuid.UUID      `json:"competition_id"`
+	StartDate     time.Time      `json:"start_date"`
+	EndDate       time.Time      `json:"end_date"`
+	Rounds        int32          `json:"rounds"`
+	Teams         []TeamResponse `json:"teams"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	DeletedAt     zero.Time      `json:"deleted_at"`
 }

--- a/api/http/handlers/season.go
+++ b/api/http/handlers/season.go
@@ -49,7 +49,7 @@ func handleCreateSeason(
 			return
 		}
 
-		response.RespondSuccess(ctx, logger, http.StatusCreated, api.ToSeasonResponse(season))
+		response.RespondSuccess(ctx, logger, http.StatusCreated, service.ToSeasonResponse(season))
 	}
 }
 
@@ -79,7 +79,7 @@ func handleGetSeasons(logger zerolog.Logger, db db_handler.DB) gin.HandlerFunc {
 
 		seasonsResponse := make([]api.SeasonResponse, 0, len(seasons))
 		for _, season := range seasons {
-			seasonsResponse = append(seasonsResponse, api.ToSeasonResponse(season))
+			seasonsResponse = append(seasonsResponse, service.ToSeasonResponse(season))
 		}
 
 		response.RespondSuccess(ctx, logger, http.StatusOK, seasonsResponse)
@@ -118,7 +118,7 @@ func handleGetSeason(logger zerolog.Logger, db db_handler.DB) gin.HandlerFunc {
 			return
 		}
 
-		response.RespondSuccess(ctx, logger, http.StatusOK, api.ToSeasonResponse(season))
+		response.RespondSuccess(ctx, logger, http.StatusOK, service.ToSeasonResponse(season))
 	}
 }
 
@@ -163,7 +163,7 @@ func handleUpdateSeason(logger zerolog.Logger, db db_handler.DB) gin.HandlerFunc
 			return
 		}
 
-		response.RespondSuccess(ctx, logger, http.StatusOK, api.ToSeasonResponse(season))
+		response.RespondSuccess(ctx, logger, http.StatusOK, service.ToSeasonResponse(season))
 	}
 }
 

--- a/api/query.sql
+++ b/api/query.sql
@@ -221,3 +221,48 @@ WHERE
 	id = @id
 AND
 	deleted_at IS NULL;
+
+-- name: CreateSeasonTeams :exec
+-- Insert a new season_teams relationship
+INSERT INTO season_teams (
+  id,
+  team_id,
+  season_id,
+  created_at,
+  updated_at,
+  deleted_at
+)
+VALUES (
+  @id,
+  @team_id,
+  @season_id,
+  @created_at,
+  @updated_at,
+  @deleted_at
+);
+
+-- name: GetSeasonTeams :many
+-- Fetch all season_teams
+SELECT
+  id,
+  team_id,
+  season_id,
+  created_at,
+  updated_at,
+  deleted_at
+FROM
+  season_teams
+WHERE
+  season_id = @season_id
+AND
+  deleted_at IS NULL;
+
+-- name: DeleteSeasonTeam :exec
+-- Soft delete a team_season record
+UPDATE season_teams
+SET
+  deleted_at = @deleted_at
+WHERE
+  id = @id
+AND
+  deleted_at IS NULL;

--- a/api/service/season.go
+++ b/api/service/season.go
@@ -9,27 +9,59 @@ import (
 	"github.com/bradley-adams/gainline/db/db_handler"
 	"github.com/bradley-adams/gainline/http/api"
 	"github.com/google/uuid"
+	"github.com/guregu/null/zero"
 	"github.com/pkg/errors"
 )
+
+type SeasonWithTeams struct {
+	ID            uuid.UUID `json:"id"`
+	CompetitionID uuid.UUID `json:"competition_id"`
+	StartDate     time.Time `json:"start_date"`
+	EndDate       time.Time `json:"end_date"`
+	Rounds        int32     `json:"rounds"`
+	Teams         []db.Team `json:"teams"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+	DeletedAt     zero.Time `json:"deleted_at"`
+}
+
+func ToSeasonResponse(s SeasonWithTeams) api.SeasonResponse {
+	var teams []api.TeamResponse
+	for _, team := range s.Teams {
+		teams = append(teams, api.ToTeamResponse(team))
+	}
+
+	return api.SeasonResponse{
+		ID:            s.ID,
+		CompetitionID: s.CompetitionID,
+		StartDate:     s.StartDate,
+		EndDate:       s.EndDate,
+		Rounds:        s.Rounds,
+		Teams:         teams,
+		CreatedAt:     s.CreatedAt,
+		UpdatedAt:     s.UpdatedAt,
+		DeletedAt:     zero.TimeFrom(s.DeletedAt.Time),
+	}
+}
 
 func CreateSeason(
 	ctx context.Context,
 	dbHandler db_handler.DB,
 	req *api.SeasonRequest,
 	competitionID uuid.UUID,
-) (db.Season, error) {
-	var season db.Season
+) (SeasonWithTeams, error) {
+	var seasonWithTeams SeasonWithTeams
 
 	err := db_handler.RunInTransaction(ctx, dbHandler, func(queries db_handler.Queries) error {
 		var err error
-		season, err = createSeason(ctx, queries, req, competitionID)
+		seasonWithTeams, err = createSeason(ctx, queries, req, competitionID)
 		return err
 	})
 	if err != nil {
-		return db.Season{}, err
+		return SeasonWithTeams{}, err
 	}
 
-	return season, nil
+	return seasonWithTeams, nil
 }
 
 func createSeason(
@@ -37,10 +69,31 @@ func createSeason(
 	queries db_handler.Queries,
 	req *api.SeasonRequest,
 	competitionID uuid.UUID,
-) (db.Season, error) {
+) (SeasonWithTeams, error) {
 	now := time.Now()
+	seasonID := uuid.New()
+
+	if err := insertSeason(ctx, queries, seasonID, competitionID, req, now); err != nil {
+		return SeasonWithTeams{}, err
+	}
+
+	teamIDs := dedupeUUIDs(req.TeamIDs)
+	if err := ensureSeasonHasTeams(ctx, queries, seasonID, teamIDs, now, nil); err != nil {
+		return SeasonWithTeams{}, err
+	}
+
+	return getSeasonWithTeams(ctx, queries, seasonID)
+}
+
+func insertSeason(
+	ctx context.Context,
+	queries db_handler.Queries,
+	seasonID, competitionID uuid.UUID,
+	req *api.SeasonRequest,
+	now time.Time,
+) error {
 	createSeasonParams := db.CreateSeasonParams{
-		ID:            uuid.New(),
+		ID:            seasonID,
 		CompetitionID: competitionID,
 		StartDate:     req.StartDate,
 		EndDate:       req.EndDate,
@@ -49,34 +102,116 @@ func createSeason(
 		UpdatedAt:     now,
 		DeletedAt:     sql.NullTime{Time: time.Time{}, Valid: false},
 	}
+	if err := queries.CreateSeason(ctx, createSeasonParams); err != nil {
+		return errors.Wrap(err, "unable to create new season")
+	}
+	return nil
+}
 
-	err := queries.CreateSeason(ctx, createSeasonParams)
-	if err != nil {
-		return db.Season{}, errors.Wrap(err, "unable to create new season")
+func ensureTeamsExist(ctx context.Context, queries db_handler.Queries, teamIDs []uuid.UUID) error {
+	for _, id := range teamIDs {
+		if _, err := queries.GetTeam(ctx, id); err != nil {
+			return errors.Wrapf(err, "unable to find team %s", id.String())
+		}
+	}
+	return nil
+}
+
+func ensureSeasonHasTeams(
+	ctx context.Context,
+	queries db_handler.Queries,
+	seasonID uuid.UUID,
+	teamIDs []uuid.UUID,
+	now time.Time,
+	existingMap map[uuid.UUID]db.GetSeasonTeamsRow, // pass nil when not pre-fetched
+) error {
+	// validate existence
+	if err := ensureTeamsExist(ctx, queries, teamIDs); err != nil {
+		return err
 	}
 
-	season, err := queries.GetSeason(ctx, createSeasonParams.ID)
+	for _, teamID := range teamIDs {
+		if existingMap != nil {
+			if _, already := existingMap[teamID]; already {
+				continue
+			}
+		}
+
+		createSeasonTeamsParams := db.CreateSeasonTeamsParams{
+			ID:        uuid.New(),
+			SeasonID:  seasonID,
+			TeamID:    teamID,
+			CreatedAt: now,
+			UpdatedAt: now,
+			DeletedAt: sql.NullTime{Time: time.Time{}, Valid: false},
+		}
+		if err := queries.CreateSeasonTeams(ctx, createSeasonTeamsParams); err != nil {
+			return errors.Wrapf(err, "unable to add team %s to season %s", teamID.String(), seasonID.String())
+		}
+	}
+	return nil
+}
+
+func getSeasonWithTeams(
+	ctx context.Context,
+	queries db_handler.Queries,
+	seasonID uuid.UUID,
+) (SeasonWithTeams, error) {
+	season, err := queries.GetSeason(ctx, seasonID)
 	if err != nil {
-		return db.Season{}, errors.Wrap(err, "unable to get new season")
+		return SeasonWithTeams{}, errors.Wrap(err, "unable to get season after creation")
 	}
 
-	return season, nil
+	seasonTeams, err := queries.GetSeasonTeams(ctx, season.ID)
+	if err != nil {
+		return SeasonWithTeams{}, errors.Wrap(err, "unable to get season teams")
+	}
+
+	var teams []db.Team
+	for _, st := range seasonTeams {
+		team, err := queries.GetTeam(ctx, st.TeamID)
+		if err != nil {
+			return SeasonWithTeams{}, errors.Wrap(err, "unable to get team")
+		}
+		teams = append(teams, team)
+	}
+
+	return SeasonWithTeams{
+		ID:            season.ID,
+		CompetitionID: season.CompetitionID,
+		StartDate:     season.StartDate,
+		EndDate:       season.EndDate,
+		Rounds:        season.Rounds,
+		Teams:         teams,
+		CreatedAt:     season.CreatedAt,
+		UpdatedAt:     season.UpdatedAt,
+		DeletedAt:     zero.TimeFrom(season.DeletedAt.Time),
+	}, nil
+}
+
+func dedupeUUIDs(in []uuid.UUID) []uuid.UUID {
+	m := make(map[uuid.UUID]struct{}, len(in))
+	for _, id := range in {
+		m[id] = struct{}{}
+	}
+	out := make([]uuid.UUID, 0, len(m))
+	for id := range m {
+		out = append(out, id)
+	}
+	return out
 }
 
 func GetSeasons(
 	ctx context.Context,
 	dbHandler db_handler.DB,
 	competitionID uuid.UUID,
-) ([]db.Season, error) {
-	var seasons []db.Season
+) ([]SeasonWithTeams, error) {
+	var seasons []SeasonWithTeams
 
 	err := db_handler.Run(ctx, dbHandler, func(queries db_handler.Queries) error {
 		var err error
-		seasons, err = queries.GetSeasons(ctx, competitionID)
-		if err != nil {
-			return errors.Wrap(err, "unable to get seasons")
-		}
-		return nil
+		seasons, err = getSeasons(ctx, queries, competitionID)
+		return err
 	})
 	if err != nil {
 		return nil, err
@@ -85,30 +220,59 @@ func GetSeasons(
 	return seasons, nil
 }
 
+func getSeasons(
+	ctx context.Context,
+	queries db_handler.Queries,
+	competitionID uuid.UUID,
+) ([]SeasonWithTeams, error) {
+	var seasonsWithTeams []SeasonWithTeams
+
+	seasons, err := queries.GetSeasons(ctx, competitionID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get seasons")
+	}
+
+	for _, s := range seasons {
+		swt, err := getSeasonWithTeams(ctx, queries, s.ID)
+		if err != nil {
+			return nil, err
+		}
+		seasonsWithTeams = append(seasonsWithTeams, swt)
+	}
+
+	return seasonsWithTeams, nil
+}
+
 func GetSeason(
 	ctx context.Context,
 	dbHandler db_handler.DB,
 	competitionID uuid.UUID,
 	seasonID uuid.UUID,
-) (db.Season, error) {
-	var season db.Season
+) (SeasonWithTeams, error) {
+	var season SeasonWithTeams
 
 	err := db_handler.Run(ctx, dbHandler, func(queries db_handler.Queries) error {
 		var err error
-		season, err = queries.GetSeason(ctx, seasonID)
-		if err != nil {
-			return errors.Wrap(err, "unable to get season")
-		}
-		if season.CompetitionID != competitionID {
-			return errors.New("season does not belong to the specified competition")
-		}
-		return nil
+		season, err = getSeason(ctx, queries, competitionID, seasonID)
+		return err
 	})
 	if err != nil {
-		return db.Season{}, err
+		return SeasonWithTeams{}, err
 	}
 
 	return season, nil
+}
+
+func getSeason(
+	ctx context.Context,
+	queries db_handler.Queries,
+	competitionID, seasonID uuid.UUID,
+) (SeasonWithTeams, error) {
+	if _, err := validateSeasonOwnership(ctx, queries, seasonID, competitionID); err != nil {
+		return SeasonWithTeams{}, err
+	}
+
+	return getSeasonWithTeams(ctx, queries, seasonID)
 }
 
 func UpdateSeason(
@@ -117,19 +281,19 @@ func UpdateSeason(
 	req *api.SeasonRequest,
 	competitionID uuid.UUID,
 	seasonID uuid.UUID,
-) (db.Season, error) {
-	var season db.Season
+) (SeasonWithTeams, error) {
+	var seasonWithTeams SeasonWithTeams
 
 	err := db_handler.RunInTransaction(ctx, dbHandler, func(queries db_handler.Queries) error {
 		var txErr error
-		season, txErr = updateSeason(ctx, queries, req, competitionID, seasonID)
+		seasonWithTeams, txErr = updateSeason(ctx, queries, req, competitionID, seasonID)
 		return txErr
 	})
 	if err != nil {
-		return db.Season{}, err
+		return SeasonWithTeams{}, err
 	}
 
-	return season, nil
+	return seasonWithTeams, nil
 }
 
 func updateSeason(
@@ -138,17 +302,50 @@ func updateSeason(
 	req *api.SeasonRequest,
 	competitionID uuid.UUID,
 	seasonID uuid.UUID,
+) (SeasonWithTeams, error) {
+	_, err := validateSeasonOwnership(ctx, queries, seasonID, competitionID)
+	if err != nil {
+		return SeasonWithTeams{}, err
+	}
+
+	now := time.Now()
+
+	err = updateSeasonFields(ctx, queries, req, competitionID, seasonID, now)
+	if err != nil {
+		return SeasonWithTeams{}, err
+	}
+
+	// dedupe + sync teams (adds missing and removes extras)
+	err = syncSeasonTeams(ctx, queries, seasonID, req.TeamIDs, now)
+	if err != nil {
+		return SeasonWithTeams{}, err
+	}
+
+	return getSeasonWithTeams(ctx, queries, seasonID)
+}
+
+func validateSeasonOwnership(
+	ctx context.Context,
+	queries db_handler.Queries,
+	seasonID, competitionID uuid.UUID,
 ) (db.Season, error) {
 	season, err := queries.GetSeason(ctx, seasonID)
 	if err != nil {
 		return db.Season{}, errors.Wrap(err, "unable to get season for update")
 	}
-
 	if season.CompetitionID != competitionID {
 		return db.Season{}, errors.New("season does not belong to the specified competition")
 	}
+	return season, nil
+}
 
-	now := time.Now()
+func updateSeasonFields(
+	ctx context.Context,
+	queries db_handler.Queries,
+	req *api.SeasonRequest,
+	competitionID, seasonID uuid.UUID,
+	now time.Time,
+) error {
 	updateSeasonParams := db.UpdateSeasonParams{
 		CompetitionID: competitionID,
 		StartDate:     req.StartDate,
@@ -158,17 +355,101 @@ func updateSeason(
 		ID:            seasonID,
 	}
 
-	err = queries.UpdateSeason(ctx, updateSeasonParams)
+	err := queries.UpdateSeason(ctx, updateSeasonParams)
 	if err != nil {
-		return db.Season{}, errors.Wrap(err, "unable to update season")
+		return errors.Wrap(err, "unable to update season")
+	}
+	return nil
+}
+
+func syncSeasonTeams(
+	ctx context.Context,
+	queries db_handler.Queries,
+	seasonID uuid.UUID,
+	rawTeamIDs []uuid.UUID,
+	now time.Time,
+) error {
+	requestedTeamIDs, err := validateRequestedTeams(ctx, queries, rawTeamIDs)
+	if err != nil {
+		return err
 	}
 
-	updatedSeason, err := queries.GetSeason(ctx, seasonID)
+	existingLinks, requestedSet, existingMap, err := buildSeasonTeamMaps(ctx, queries, seasonID, requestedTeamIDs)
 	if err != nil {
-		return db.Season{}, errors.Wrap(err, "unable to get updated season")
+		return err
 	}
 
-	return updatedSeason, nil
+	if err := ensureSeasonHasTeams(ctx, queries, seasonID, requestedTeamIDs, now, existingMap); err != nil {
+		return err
+	}
+
+	if err := removeExtraSeasonTeams(ctx, queries, seasonID, existingLinks, requestedSet); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateRequestedTeams(
+	ctx context.Context,
+	queries db_handler.Queries,
+	rawTeamIDs []uuid.UUID,
+) ([]uuid.UUID, error) {
+	requestedTeamIDs := dedupeUUIDs(rawTeamIDs)
+	if err := ensureTeamsExist(ctx, queries, requestedTeamIDs); err != nil {
+		return nil, err
+	}
+	return requestedTeamIDs, nil
+}
+
+func buildSeasonTeamMaps(
+	ctx context.Context,
+	queries db_handler.Queries,
+	seasonID uuid.UUID,
+	requestedTeamIDs []uuid.UUID,
+) ([]db.GetSeasonTeamsRow, map[uuid.UUID]struct{}, map[uuid.UUID]db.GetSeasonTeamsRow, error) {
+	existingLinks, err := queries.GetSeasonTeams(ctx, seasonID)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "unable to get season's existing teams")
+	}
+
+	requestedSet := make(map[uuid.UUID]struct{}, len(requestedTeamIDs))
+	for _, id := range requestedTeamIDs {
+		requestedSet[id] = struct{}{}
+	}
+
+	existingMap := make(map[uuid.UUID]db.GetSeasonTeamsRow, len(existingLinks))
+	for _, st := range existingLinks {
+		existingMap[st.TeamID] = st
+	}
+
+	return existingLinks, requestedSet, existingMap, nil
+}
+
+func removeExtraSeasonTeams(
+	ctx context.Context,
+	queries db_handler.Queries,
+	seasonID uuid.UUID,
+	existingLinks []db.GetSeasonTeamsRow,
+	requestedSet map[uuid.UUID]struct{},
+) error {
+	for _, st := range existingLinks {
+		_, keep := requestedSet[st.TeamID]
+		if keep {
+			continue
+		}
+
+		deleteParams := db.DeleteSeasonTeamParams{
+			ID:        st.ID,
+			DeletedAt: sql.NullTime{Time: time.Now(), Valid: true},
+		}
+
+		err := queries.DeleteSeasonTeam(ctx, deleteParams)
+		if err != nil {
+			return errors.Wrapf(err, "unable to remove team %s from season %s", st.TeamID.String(), seasonID.String())
+		}
+	}
+	return nil
 }
 
 func DeleteSeason(
@@ -197,15 +478,47 @@ func deleteSeason(
 		return errors.New("season does not belong to the specified competition")
 	}
 
-	deleteSeasonParams := db.DeleteSeasonParams{
-		ID:        season.ID,
-		DeletedAt: sql.NullTime{Time: time.Now(), Valid: true},
+	now := time.Now()
+
+	// Soft-delete all season_team links
+	if err := deleteSeasonTeams(ctx, queries, seasonID, now); err != nil {
+		return err
 	}
 
-	err = queries.DeleteSeason(ctx, deleteSeasonParams)
-	if err != nil {
+	// Soft-delete the season itself
+	deleteSeasonParams := db.DeleteSeasonParams{
+		ID:        season.ID,
+		DeletedAt: sql.NullTime{Time: now, Valid: true},
+	}
+
+	if err := queries.DeleteSeason(ctx, deleteSeasonParams); err != nil {
 		return errors.Wrap(err, "unable to delete season")
 	}
 
+	return nil
+}
+
+func deleteSeasonTeams(
+	ctx context.Context,
+	queries db_handler.Queries,
+	seasonID uuid.UUID,
+	now time.Time,
+) error {
+	seasonTeams, err := queries.GetSeasonTeams(ctx, seasonID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get season teams for deletion")
+	}
+
+	for _, st := range seasonTeams {
+		deleteParams := db.DeleteSeasonTeamParams{
+			ID:        st.ID,
+			DeletedAt: sql.NullTime{Time: now, Valid: true},
+		}
+
+		err := queries.DeleteSeasonTeam(ctx, deleteParams)
+		if err != nil {
+			return errors.Wrapf(err, "unable to remove team %s from season %s", st.TeamID.String(), seasonID.String())
+		}
+	}
 	return nil
 }

--- a/database/migrations/000002_create_season_games_teams_tables.up.sql
+++ b/database/migrations/000002_create_season_games_teams_tables.up.sql
@@ -28,6 +28,19 @@ CREATE TABLE teams (
     deleted_at TIMESTAMP WITH TIME ZONE
 );
 
+CREATE TABLE season_teams (
+    id UUID PRIMARY KEY,
+    season_id UUID NOT NULL,
+    team_id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE,
+    CONSTRAINT fk_season_teams_season FOREIGN KEY (season_id) REFERENCES seasons(id) ON DELETE CASCADE,
+    CONSTRAINT fk_season_teams_team FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE,
+    UNIQUE (season_id, team_id)
+);
+
+
 CREATE TYPE game_status AS ENUM ('scheduled', 'playing', 'finished');
 
 CREATE TABLE games (

--- a/database/migrations/000003_insert_seed_data.up.sql
+++ b/database/migrations/000003_insert_seed_data.up.sql
@@ -34,6 +34,23 @@ VALUES
 ('dedb2044-1d2f-4dc7-84c6-509ec69c82e1', 'Hawke''s Bay', 'HKB', 'Napier', now(), now()),
 ('6b5c3642-c026-4e89-81f7-024c40638f9a', 'Counties Manukau', 'CMK', 'Pukekohe', now(), now());
 
+INSERT INTO season_teams (id, season_id, team_id, created_at, updated_at, deleted_at)
+VALUES
+('8fc1cc1b-7de1-464a-b3c5-7db1806f3661', '9300778f-cce0-4efe-af6c-e399d8170315', '013952a5-87e1-4d26-a312-09b2aff54241', now(), now(), NULL),
+('f414e700-8b43-4870-812d-783a5b9ddb2d', '9300778f-cce0-4efe-af6c-e399d8170315', '7b6cdb33-3bc6-4b0c-bac2-82d2a6bc6a97', now(), now(), NULL),
+('84d4696e-67ae-4836-a3a9-336c7bb4c4fe', '9300778f-cce0-4efe-af6c-e399d8170315', '636f1f87-bc47-4e63-a3de-bf7cb8eb0c22', now(), now(), NULL),
+('ad73b809-eb3b-48af-9d50-e26951f52702', '9300778f-cce0-4efe-af6c-e399d8170315', 'e2d6c2bb-eac6-42d6-8727-4d4cbeb3e3d7', now(), now(), NULL),
+('869a0f34-f15d-45ef-b13f-eb551050a849', '9300778f-cce0-4efe-af6c-e399d8170315', 'ab4c78b1-5dc6-4a14-8f15-d1f144b81d96', now(), now(), NULL),
+('e587e373-986d-4be6-a894-70bf62367455', '9300778f-cce0-4efe-af6c-e399d8170315', 'f192a9ce-dce2-4389-8491-1a193ac7699e', now(), now(), NULL),
+('a3d1dd91-2bfc-4819-9e52-7e5cb7ea2fdd', '9300778f-cce0-4efe-af6c-e399d8170315', '15c76909-f78a-4d89-bc19-7c80265e1e08', now(), now(), NULL),
+('cbcf4c8a-4172-4a38-8ea0-19dd2282df1f', '9300778f-cce0-4efe-af6c-e399d8170315', 'a5d930c3-13aa-4a85-b5c9-8f40c2c61c8a', now(), now(), NULL),
+('3071577c-0130-4b75-b778-0f843981aff0', '9300778f-cce0-4efe-af6c-e399d8170315', 'bfe6ec41-e3f0-4f8f-90d2-d7bca66e1a1f', now(), now(), NULL),
+('575c1e41-04f4-47cc-9179-19cd0e0227a9', '9300778f-cce0-4efe-af6c-e399d8170315', '7e5abf68-8358-4c20-b6a4-f64ef264c13c', now(), now(), NULL),
+('6e45c89b-ef37-4593-b6c1-1fe4a054deb7', '9300778f-cce0-4efe-af6c-e399d8170315', 'b5c6e9d7-8f11-4ef2-acc6-2e5a97839532', now(), now(), NULL),
+('fdc63492-8ff1-4610-92f1-82f629524404', '9300778f-cce0-4efe-af6c-e399d8170315', '19b3ea1e-0c46-41f3-84ea-490b6b1db30f', now(), now(), NULL),
+('9a6d021d-1daa-4320-a6ea-4b62dd8ac5c5', '9300778f-cce0-4efe-af6c-e399d8170315', 'dedb2044-1d2f-4dc7-84c6-509ec69c82e1', now(), now(), NULL),
+('ae444444-4444-4444-4444-444444444444', '9300778f-cce0-4efe-af6c-e399d8170315', '6b5c3642-c026-4e89-81f7-024c40638f9a', now(), now(), NULL);
+
 -- Insert games
 INSERT INTO games (
     id, season_id, round, date,


### PR DESCRIPTION
Teams no longer belong to competitions directly. We have a many to many relationship with teams and seasons so we are using a mapper table. This relationship is managed by the season routes. Takes an array of UUIDs on request and returns and array of TeamResponses. 