### PR TITLE
Gainline - Updating season tests to account for season tests

### DIFF
--- a/api/db/db_handler/mock/db.go
+++ b/api/db/db_handler/mock/db.go
@@ -239,6 +239,20 @@ func (mr *MockQueriesMockRecorder) CreateSeason(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSeason", reflect.TypeOf((*MockQueries)(nil).CreateSeason), arg0, arg1)
 }
 
+// CreateSeasonTeams mocks base method.
+func (m *MockQueries) CreateSeasonTeams(arg0 context.Context, arg1 db.CreateSeasonTeamsParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSeasonTeams", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateSeasonTeams indicates an expected call of CreateSeasonTeams.
+func (mr *MockQueriesMockRecorder) CreateSeasonTeams(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSeasonTeams", reflect.TypeOf((*MockQueries)(nil).CreateSeasonTeams), arg0, arg1)
+}
+
 // CreateTeam mocks base method.
 func (m *MockQueries) CreateTeam(arg0 context.Context, arg1 db.CreateTeamParams) error {
 	m.ctrl.T.Helper()
@@ -279,6 +293,20 @@ func (m *MockQueries) DeleteSeason(arg0 context.Context, arg1 db.DeleteSeasonPar
 func (mr *MockQueriesMockRecorder) DeleteSeason(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSeason", reflect.TypeOf((*MockQueries)(nil).DeleteSeason), arg0, arg1)
+}
+
+// DeleteSeasonTeam mocks base method.
+func (m *MockQueries) DeleteSeasonTeam(arg0 context.Context, arg1 db.DeleteSeasonTeamParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSeasonTeam", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSeasonTeam indicates an expected call of DeleteSeasonTeam.
+func (mr *MockQueriesMockRecorder) DeleteSeasonTeam(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSeasonTeam", reflect.TypeOf((*MockQueries)(nil).DeleteSeasonTeam), arg0, arg1)
 }
 
 // DeleteTeam mocks base method.
@@ -338,6 +366,21 @@ func (m *MockQueries) GetSeason(arg0 context.Context, arg1 uuid.UUID) (db.Season
 func (mr *MockQueriesMockRecorder) GetSeason(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeason", reflect.TypeOf((*MockQueries)(nil).GetSeason), arg0, arg1)
+}
+
+// GetSeasonTeams mocks base method.
+func (m *MockQueries) GetSeasonTeams(arg0 context.Context, arg1 uuid.UUID) ([]db.GetSeasonTeamsRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSeasonTeams", arg0, arg1)
+	ret0, _ := ret[0].([]db.GetSeasonTeamsRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSeasonTeams indicates an expected call of GetSeasonTeams.
+func (mr *MockQueriesMockRecorder) GetSeasonTeams(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeasonTeams", reflect.TypeOf((*MockQueries)(nil).GetSeasonTeams), arg0, arg1)
 }
 
 // GetSeasons mocks base method.

--- a/api/service/season_test.go
+++ b/api/service/season_test.go
@@ -3,12 +3,14 @@ package service
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/bradley-adams/gainline/db/db"
 	mock_db "github.com/bradley-adams/gainline/db/db_handler/mock"
 	"github.com/bradley-adams/gainline/http/api"
 	"github.com/google/uuid"
+	"github.com/guregu/null/zero"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -32,16 +34,26 @@ var _ = Describe("season", func() {
 	validCompetitionID := uuid.New()
 	invalidCompetitionID := uuid.New()
 
+	validSeasonTeamID := uuid.New()
+	validSeasonTeamID2 := uuid.New()
+	validSeasonTeamID3 := uuid.New()
+
+	validTeamID := uuid.New()
+	validTeamID2 := uuid.New()
+	validTeamID3 := uuid.New()
+
+	validTeamIDs := []uuid.UUID{validTeamID, validTeamID2}
+
 	validTimeNow := time.Now()
 
 	validSeasonRequest := &api.SeasonRequest{
 		StartDate: validTimeNow,
 		EndDate:   validTimeNow.AddDate(0, 5, 0),
 		Rounds:    15,
+		TeamIDs:   validTeamIDs,
 	}
 
 	var validNilSeason db.Season
-	var validNilSeasons []db.Season
 
 	validSeasonFromDB := db.Season{
 		ID:            validSeasonID,
@@ -70,9 +82,93 @@ var _ = Describe("season", func() {
 		validSeasonFromDB2,
 	}
 
-	validSeasonResponse := api.ToSeasonResponse(validSeasonFromDB)
+	validTeamFromDB := db.Team{
+		ID:           validTeamID,
+		Name:         "Test Team",
+		Abbreviation: "TT",
+		Location:     "Testville",
+		CreatedAt:    validTimeNow,
+		UpdatedAt:    validTimeNow,
+		DeletedAt:    sql.NullTime{Time: time.Time{}, Valid: false},
+	}
 
-	validSeasonResponse2 := api.ToSeasonResponse(validSeasonFromDB2)
+	validTeamFromDB2 := db.Team{
+		ID:           validTeamID2,
+		Name:         "Test Team2",
+		Abbreviation: "TT2",
+		Location:     "Testville 22",
+		CreatedAt:    validTimeNow,
+		UpdatedAt:    validTimeNow,
+		DeletedAt:    sql.NullTime{Time: time.Time{}, Valid: false},
+	}
+
+	validSeasonTeamFromDB := db.GetSeasonTeamsRow{
+		ID:        validSeasonTeamID,
+		TeamID:    validTeamID,
+		SeasonID:  validSeasonID,
+		CreatedAt: validTimeNow,
+		UpdatedAt: validTimeNow,
+		DeletedAt: sql.NullTime{Time: time.Time{}, Valid: false},
+	}
+
+	validSeasonTeamFromDB2 := db.GetSeasonTeamsRow{
+		ID:        validSeasonTeamID2,
+		TeamID:    validTeamID2,
+		SeasonID:  validSeasonID,
+		CreatedAt: validTimeNow,
+		UpdatedAt: validTimeNow,
+		DeletedAt: sql.NullTime{Time: time.Time{}, Valid: false},
+	}
+
+	validSeasonTeamFromDB3 := db.GetSeasonTeamsRow{
+		ID:        validSeasonTeamID3,
+		TeamID:    validTeamID3,
+		SeasonID:  validSeasonID,
+		CreatedAt: validTimeNow,
+		UpdatedAt: validTimeNow,
+		DeletedAt: sql.NullTime{Time: time.Time{}, Valid: false},
+	}
+
+	validSeasonTeamsFromDB := []db.GetSeasonTeamsRow{
+		validSeasonTeamFromDB,
+		validSeasonTeamFromDB2,
+	}
+
+	validSeasonTeamsFromDB2 := []db.GetSeasonTeamsRow{
+		validSeasonTeamFromDB,
+		validSeasonTeamFromDB3,
+	}
+
+	var validNilSeasonWithTeams SeasonWithTeams
+	var validNilSeasonsWithTeams []SeasonWithTeams
+
+	validSeasonWithTeams := SeasonWithTeams{
+		ID:            validSeasonFromDB.ID,
+		CompetitionID: validSeasonFromDB.CompetitionID,
+		StartDate:     validSeasonFromDB.StartDate,
+		EndDate:       validSeasonFromDB.EndDate,
+		Rounds:        validSeasonFromDB.Rounds,
+		Teams:         []db.Team{},
+		CreatedAt:     validSeasonFromDB.CreatedAt,
+		UpdatedAt:     validSeasonFromDB.UpdatedAt,
+		DeletedAt:     zero.TimeFrom(validSeasonFromDB.DeletedAt.Time),
+	}
+
+	validSeasonWithTeams2 := SeasonWithTeams{
+		ID:            validSeasonFromDB2.ID,
+		CompetitionID: validSeasonFromDB2.CompetitionID,
+		StartDate:     validSeasonFromDB2.StartDate,
+		EndDate:       validSeasonFromDB2.EndDate,
+		Rounds:        validSeasonFromDB2.Rounds,
+		Teams:         []db.Team{},
+		CreatedAt:     validSeasonFromDB2.CreatedAt,
+		UpdatedAt:     validSeasonFromDB2.UpdatedAt,
+		DeletedAt:     zero.TimeFrom(validSeasonFromDB2.DeletedAt.Time),
+	}
+
+	validSeasonResponse := ToSeasonResponse(validSeasonWithTeams)
+
+	validSeasonResponse2 := ToSeasonResponse(validSeasonWithTeams2)
 
 	validSeasonsResponse := []api.SeasonResponse{
 		validSeasonResponse,
@@ -94,10 +190,38 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().GetSeason(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
 			mockDB.EXPECT().Commit(
 				gomock.Any(),
 			)
@@ -129,8 +253,8 @@ var _ = Describe("season", func() {
 
 			season, err := CreateSeason(context.Background(), mockDB, validSeasonRequest, validCompetitionID)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal(validTestError.Error()))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed creating season: a valid testing error"))
 		})
 
 		It("insert season error should return formatted and then rollback", func() {
@@ -151,8 +275,70 @@ var _ = Describe("season", func() {
 
 			season, err := CreateSeason(context.Background(), mockDB, validSeasonRequest, validCompetitionID)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal("unable to create new season: a valid testing error"))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed creating season: unable to create season: a valid testing error"))
+		})
+
+		It("get team error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().CreateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			season, err := CreateSeason(context.Background(), mockDB, validSeasonRequest, validCompetitionID)
+
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err).To(MatchError(ContainSubstring("failed creating season: unable to get team ")))
+			Expect(err.Error()).To(ContainSubstring(": a valid testing error"))
+		})
+
+		It("create season teams error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().CreateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			season, err := CreateSeason(context.Background(), mockDB, validSeasonRequest, validCompetitionID)
+
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err).To(MatchError(ContainSubstring("failed creating season: unable to add team ")))
+			Expect(err.Error()).To(ContainSubstring(": a valid testing error"))
 		})
 
 		It("get season error should return formatted and then rollback", func() {
@@ -167,6 +353,22 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().GetSeason(
 				gomock.Any(),
 				gomock.Any(),
@@ -177,8 +379,8 @@ var _ = Describe("season", func() {
 
 			season, err := CreateSeason(context.Background(), mockDB, validSeasonRequest, validCompetitionID)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal("unable to get new season: a valid testing error"))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed creating season: unable to get season: a valid testing error"))
 		})
 
 		It("a commit error should return formatted", func() {
@@ -193,10 +395,30 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().GetSeason(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return([]db.GetSeasonTeamsRow{}, nil)
 			mockDB.EXPECT().Commit(
 				gomock.Any(),
 			).Return(validTestError)
@@ -206,8 +428,8 @@ var _ = Describe("season", func() {
 
 			season, err := CreateSeason(context.Background(), mockDB, validSeasonRequest, validCompetitionID)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal(validTestError.Error()))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed creating season: a valid testing error"))
 		})
 	})
 
@@ -220,6 +442,14 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonsFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil, nil)
 
 			seasons, err := GetSeasons(context.Background(), mockDB, validCompetitionID)
 			Expect(err).NotTo(HaveOccurred())
@@ -254,8 +484,28 @@ var _ = Describe("season", func() {
 
 			seasons, err := GetSeasons(context.Background(), mockDB, validCompetitionID)
 
-			Expect(seasons).To(Equal(validNilSeasons))
-			Expect(err.Error()).To(Equal("unable to get seasons: a valid testing error"))
+			Expect(seasons).To(Equal(validNilSeasonsWithTeams))
+			Expect(err.Error()).To(Equal("failed getting seasons: unable to get seasons: a valid testing error"))
+		})
+
+		It("get season teams error should return formatted", func() {
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeasons(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonsFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil, validTestError)
+
+			seasons, err := GetSeasons(context.Background(), mockDB, validCompetitionID)
+
+			Expect(seasons).To(Equal(validNilSeasonsWithTeams))
+			Expect(err.Error()).To(Equal("failed getting seasons: unable to get season teams: a valid testing error"))
+
 		})
 	})
 
@@ -268,6 +518,14 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return([]db.GetSeasonTeamsRow{}, nil)
 
 			season, err := GetSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
 			Expect(err).NotTo(HaveOccurred())
@@ -293,8 +551,31 @@ var _ = Describe("season", func() {
 
 			season, err := GetSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal("unable to get season: a valid testing error"))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed getting season: unable to get season: a valid testing error"))
+		})
+
+		It("get season teams error should return formatted", func() {
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return([]db.GetSeasonTeamsRow{}, validTestError)
+
+			season, err := GetSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed getting season: unable to get season teams: a valid testing error"))
 		})
 	})
 
@@ -315,10 +596,42 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB2, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().GetSeason(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
 			mockDB.EXPECT().Commit(
 				gomock.Any(),
 			)
@@ -362,8 +675,8 @@ var _ = Describe("season", func() {
 				validSeasonID,
 			)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal(validTestError.Error()))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: a valid testing error"))
 		})
 
 		It("get season error should return formatted and then rollback", func() {
@@ -390,11 +703,11 @@ var _ = Describe("season", func() {
 				validSeasonID,
 			)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal("unable to get season for update: a valid testing error"))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: unable to get season: a valid testing error"))
 		})
 
-		It("season must being to competition error should return formatted and then rollback", func() {
+		It("season must belong to competition error should return formatted and then rollback", func() {
 			mockDB.EXPECT().BeginTx(
 				gomock.Any(),
 				gomock.Any(),
@@ -418,8 +731,8 @@ var _ = Describe("season", func() {
 				validSeasonID,
 			)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal("season does not belong to the specified competition"))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: season does not belong to the specified competition"))
 		})
 
 		It("update season error should return formatted and then rollback", func() {
@@ -450,11 +763,11 @@ var _ = Describe("season", func() {
 				validSeasonID,
 			)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal("unable to update season: a valid testing error"))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: unable to update season: a valid testing error"))
 		})
 
-		It("get season error should return formatted and then rollback", func() {
+		It("get team error should return formatted and then rollback", func() {
 			mockDB.EXPECT().BeginTx(
 				gomock.Any(),
 				gomock.Any(),
@@ -467,6 +780,171 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
 			mockQueries.EXPECT().UpdateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			season, err := UpdateSeason(
+				context.Background(),
+				mockDB,
+				validSeasonRequest,
+				validCompetitionID,
+				validSeasonID,
+			)
+
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			expected := fmt.Sprintf(
+				"failed updating season: unable to get team %s: a valid testing error",
+				validTeamID2.String(),
+			)
+			Expect(err).To(MatchError(expected))
+		})
+
+		It("get season team error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().UpdateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil, validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			season, err := UpdateSeason(
+				context.Background(),
+				mockDB,
+				validSeasonRequest,
+				validCompetitionID,
+				validSeasonID,
+			)
+
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: unable to get season's existing teams: a valid testing error"))
+		})
+
+		It("delete season team error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().UpdateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB2, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			season, err := UpdateSeason(
+				context.Background(),
+				mockDB,
+				validSeasonRequest,
+				validCompetitionID,
+				validSeasonID,
+			)
+
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			expected := fmt.Sprintf(
+				"failed updating season: unable to remove team %s from season %s: a valid testing error",
+				validTeamID3.String(),
+				validSeasonID.String(),
+			)
+			Expect(err).To(MatchError(expected))
+		})
+
+		It("get season after update error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().UpdateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB2, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
@@ -486,8 +964,206 @@ var _ = Describe("season", func() {
 				validSeasonID,
 			)
 
-			Expect(season).To(Equal(validNilSeason))
-			Expect(err.Error()).To(Equal("unable to get updated season: a valid testing error"))
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: unable to get season: a valid testing error"))
+		})
+
+		It("get season team after update error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().UpdateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB2, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil, validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			season, err := UpdateSeason(
+				context.Background(),
+				mockDB,
+				validSeasonRequest,
+				validCompetitionID,
+				validSeasonID,
+			)
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: unable to get season teams: a valid testing error"))
+		})
+
+		It("get team after update error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().UpdateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB2, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(db.Team{}, validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			season, err := UpdateSeason(
+				context.Background(),
+				mockDB,
+				validSeasonRequest,
+				validCompetitionID,
+				validSeasonID,
+			)
+
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: unable to get team: a valid testing error"))
+		})
+
+		It("get team after update error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().UpdateSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB2, nil)
+			mockQueries.EXPECT().CreateSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB, nil)
+			mockQueries.EXPECT().GetTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTeamFromDB2, nil)
+			mockDB.EXPECT().Commit(
+				gomock.Any(),
+			).Return(validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(0)
+
+			season, err := UpdateSeason(
+				context.Background(),
+				mockDB,
+				validSeasonRequest,
+				validCompetitionID,
+				validSeasonID,
+			)
+
+			Expect(season).To(Equal(validNilSeasonWithTeams))
+			Expect(err.Error()).To(Equal("failed updating season: a valid testing error"))
 		})
 	})
 
@@ -504,6 +1180,18 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB, nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().DeleteSeason(
 				gomock.Any(),
 				gomock.Any(),
@@ -516,6 +1204,7 @@ var _ = Describe("season", func() {
 			).Times(0)
 
 			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -530,7 +1219,7 @@ var _ = Describe("season", func() {
 
 			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
 
-			Expect(err.Error()).To(Equal(validTestError.Error()))
+			Expect(err.Error()).To(Equal("failed deleting season: a valid testing error"))
 		})
 
 		It("get season error should return formatted and then rollback", func() {
@@ -551,7 +1240,66 @@ var _ = Describe("season", func() {
 
 			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
 
-			Expect(err.Error()).To(Equal("unable to get season for deletion: a valid testing error"))
+			Expect(err.Error()).To(Equal("failed deleting season: unable to get season for deletion: a valid testing error"))
+		})
+
+		It("get season teams error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil, validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+
+			Expect(err.Error()).To(Equal("failed deleting season: unable to get season teams for deletion: a valid testing error"))
+		})
+
+		It("delete season team error should return formatted and then rollback", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB, nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+
+			expected := fmt.Sprintf(
+				"failed deleting season: unable to remove team %s from season %s: a valid testing error",
+				validTeamID.String(),
+				validSeasonID.String(),
+			)
+			Expect(err).To(MatchError(expected))
 		})
 
 		It("delete season error should return formatted and then rollback", func() {
@@ -566,6 +1314,18 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB, nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().DeleteSeason(
 				gomock.Any(),
 				gomock.Any(),
@@ -576,7 +1336,7 @@ var _ = Describe("season", func() {
 
 			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
 
-			Expect(err.Error()).To(Equal("unable to delete season: a valid testing error"))
+			Expect(err.Error()).To(Equal("failed deleting season: unable to delete season: a valid testing error"))
 		})
 
 		It("a commit error should return formatted", func() {
@@ -591,6 +1351,18 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().GetSeasonTeams(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonTeamsFromDB, nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeam(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().DeleteSeason(
 				gomock.Any(),
 				gomock.Any(),
@@ -604,7 +1376,7 @@ var _ = Describe("season", func() {
 
 			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
 
-			Expect(err.Error()).To(Equal(validTestError.Error()))
+			Expect(err.Error()).To(Equal("failed deleting season: a valid testing error"))
 		})
 	})
 })


### PR DESCRIPTION
Updating the season tests to allow for creating season teams link and also returning teams associated with a season. Teams CRUD is still managed by there own routes.