### PR TITLE
Gainline - Fix seasons teams

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -499,6 +499,12 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
@@ -1050,12 +1056,6 @@ const docTemplate = `{
         "api.SeasonRequest": {
             "type": "object",
             "properties": {
-                "TeamIDs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "end_date": {
                     "type": "string"
                 },
@@ -1064,6 +1064,12 @@ const docTemplate = `{
                 },
                 "start_date": {
                     "type": "string"
+                },
+                "teams": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -491,6 +491,12 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/response.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
@@ -1042,12 +1048,6 @@
         "api.SeasonRequest": {
             "type": "object",
             "properties": {
-                "TeamIDs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "end_date": {
                     "type": "string"
                 },
@@ -1056,6 +1056,12 @@
                 },
                 "start_date": {
                     "type": "string"
+                },
+                "teams": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -73,16 +73,16 @@ definitions:
     - GameStatusFinished
   api.SeasonRequest:
     properties:
-      TeamIDs:
-        items:
-          type: string
-        type: array
       end_date:
         type: string
       rounds:
         type: integer
       start_date:
         type: string
+      teams:
+        items:
+          type: string
+        type: array
     type: object
   api.SeasonResponse:
     properties:
@@ -465,6 +465,10 @@ paths:
             items:
               $ref: '#/definitions/api.GameResponse'
             type: array
+        "400":
+          description: Invalid ID
+          schema:
+            $ref: '#/definitions/response.ErrorResponse'
         "500":
           description: Internal server error
           schema:

--- a/api/http/api/season.go
+++ b/api/http/api/season.go
@@ -11,7 +11,7 @@ type SeasonRequest struct {
 	StartDate time.Time   `json:"start_date"`
 	EndDate   time.Time   `json:"end_date"`
 	Rounds    int32       `json:"rounds"`
-	TeamIDs   []uuid.UUID `json:"TeamIDs"`
+	Teams     []uuid.UUID `json:"teams"`
 }
 
 type SeasonResponse struct {

--- a/api/service/season.go
+++ b/api/service/season.go
@@ -78,7 +78,7 @@ func createSeason(
 		return SeasonWithTeams{}, err
 	}
 
-	teamIDs := dedupeUUIDs(req.TeamIDs)
+	teamIDs := dedupeUUIDs(req.Teams)
 	err = ensureTeamsExist(ctx, queries, teamIDs)
 	if err != nil {
 		return SeasonWithTeams{}, err
@@ -333,7 +333,7 @@ func updateSeason(
 	}
 
 	// dedupe + sync teams (adds missing and removes extras)
-	err = syncSeasonTeams(ctx, queries, seasonID, req.TeamIDs, now)
+	err = syncSeasonTeams(ctx, queries, seasonID, req.Teams, now)
 	if err != nil {
 		return SeasonWithTeams{}, err
 	}

--- a/api/service/season_test.go
+++ b/api/service/season_test.go
@@ -49,7 +49,7 @@ var _ = Describe("season", func() {
 		StartDate: validTimeNow,
 		EndDate:   validTimeNow.AddDate(0, 5, 0),
 		Rounds:    15,
-		TeamIDs:   validTeamIDs,
+		Teams:   validTeamIDs,
 	}
 
 	var validNilSeason db.Season

--- a/ui/src/app/pages/game-detail/game-detail.component.ts
+++ b/ui/src/app/pages/game-detail/game-detail.component.ts
@@ -94,7 +94,9 @@ export class GameDetailComponent {
     private loadSeason(competitionId: string, id: string): void {
         this.seasonsService.getSeason(competitionId, id).subscribe({
             next: (season: Season) => {
-                this.teams = season.teams
+                this.teams = season.teams.map((t) =>
+                    typeof t === 'string' ? ({ id: t, name: t } as Team) : t
+                )
                 this.rounds = Array.from({ length: season.rounds }, (_, i) => i + 1)
             },
             error: (err) => console.error('Error loading season:', err)

--- a/ui/src/app/pages/season-detail/season-detail.component.ts
+++ b/ui/src/app/pages/season-detail/season-detail.component.ts
@@ -90,7 +90,8 @@ export class SeasonDetailComponent {
                 this.seasonForm.patchValue({
                     start_date: season.start_date,
                     end_date: season.end_date,
-                    rounds: season.rounds
+                    rounds: season.rounds,
+                    teams: (season.teams as Team[]).map((t) => t.id)
                 })
             },
             error: (err) => console.error('Error loading season:', err)
@@ -99,7 +100,7 @@ export class SeasonDetailComponent {
 
     private createSeason(competitionId: string, newSeason: Season): void {
         this.seasonsService.createSeason(competitionId, newSeason).subscribe({
-            next: (season) => {
+            next: () => {
                 this.router.navigate(['/admin/competitions', this.competitionId, 'seasons'])
             },
             error: (err) => console.error('Error creating season:', err)
@@ -108,7 +109,7 @@ export class SeasonDetailComponent {
 
     private updateSeason(competitionId: string, id: string, updatedSeason: Season): void {
         this.seasonsService.updateSeason(competitionId, id, updatedSeason).subscribe({
-            next: (season) => {
+            next: () => {
                 this.router.navigate(['/admin/competitions', this.competitionId, 'seasons'])
             },
             error: (err) => console.error('Error updating season:', err)

--- a/ui/src/app/types/api.ts
+++ b/ui/src/app/types/api.ts
@@ -14,7 +14,7 @@ export interface Season {
     id: string
     rounds: number
     start_date: Date
-    teams: Team[]
+    teams: (string | Team)[]
     updated_at: Date
 }
 


### PR DESCRIPTION
The season teams link wasn't working. Kept teams to be able to use both ways. Ids on create/update and objects in the response.