### PR TITLE
Gainline - App level cascading deletes for seasons and games.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[go]": {
+    "editor.defaultFormatter": "golang.go"
   }
 }

--- a/api/db/db/query.sql.go
+++ b/api/db/db/query.sql.go
@@ -292,6 +292,53 @@ func (q *Queries) DeleteGame(ctx context.Context, arg DeleteGameParams) error {
 	return err
 }
 
+const deleteGamesByCompetitionID = `-- name: DeleteGamesByCompetitionID :exec
+UPDATE games
+SET
+    deleted_at = $1
+WHERE
+    season_id IN (
+        SELECT id
+        FROM seasons
+        WHERE competition_id = $2
+          AND deleted_at IS NULL
+    )
+AND
+    deleted_at IS NULL
+`
+
+type DeleteGamesByCompetitionIDParams struct {
+	DeletedAt     sql.NullTime
+	CompetitionID uuid.UUID
+}
+
+// Soft delete all games belonging to a competition via seasons
+func (q *Queries) DeleteGamesByCompetitionID(ctx context.Context, arg DeleteGamesByCompetitionIDParams) error {
+	_, err := q.db.ExecContext(ctx, deleteGamesByCompetitionID, arg.DeletedAt, arg.CompetitionID)
+	return err
+}
+
+const deleteGamesBySeasonID = `-- name: DeleteGamesBySeasonID :exec
+UPDATE games
+SET
+  deleted_at = $1
+WHERE
+  season_id = $2
+AND
+  deleted_at IS NULL
+`
+
+type DeleteGamesBySeasonIDParams struct {
+	DeletedAt sql.NullTime
+	SeasonID  uuid.UUID
+}
+
+// Soft delete all games for a given season
+func (q *Queries) DeleteGamesBySeasonID(ctx context.Context, arg DeleteGamesBySeasonIDParams) error {
+	_, err := q.db.ExecContext(ctx, deleteGamesBySeasonID, arg.DeletedAt, arg.SeasonID)
+	return err
+}
+
 const deleteSeason = `-- name: DeleteSeason :exec
 UPDATE seasons
 SET
@@ -331,6 +378,48 @@ type DeleteSeasonTeamParams struct {
 // Soft delete a team_season record
 func (q *Queries) DeleteSeasonTeam(ctx context.Context, arg DeleteSeasonTeamParams) error {
 	_, err := q.db.ExecContext(ctx, deleteSeasonTeam, arg.DeletedAt, arg.ID)
+	return err
+}
+
+const deleteSeasonTeamsBySeasonID = `-- name: DeleteSeasonTeamsBySeasonID :exec
+UPDATE season_teams
+SET
+  deleted_at = $1
+WHERE
+  season_id = $2
+AND
+  deleted_at IS NULL
+`
+
+type DeleteSeasonTeamsBySeasonIDParams struct {
+	DeletedAt sql.NullTime
+	SeasonID  uuid.UUID
+}
+
+// Soft delete all team_season records for a given season
+func (q *Queries) DeleteSeasonTeamsBySeasonID(ctx context.Context, arg DeleteSeasonTeamsBySeasonIDParams) error {
+	_, err := q.db.ExecContext(ctx, deleteSeasonTeamsBySeasonID, arg.DeletedAt, arg.SeasonID)
+	return err
+}
+
+const deleteSeasonsByCompetitionID = `-- name: DeleteSeasonsByCompetitionID :exec
+UPDATE seasons
+SET
+    deleted_at = $1
+WHERE
+    competition_id = $2
+AND
+    deleted_at IS NULL
+`
+
+type DeleteSeasonsByCompetitionIDParams struct {
+	DeletedAt     sql.NullTime
+	CompetitionID uuid.UUID
+}
+
+// Soft delete all seasons for a competition
+func (q *Queries) DeleteSeasonsByCompetitionID(ctx context.Context, arg DeleteSeasonsByCompetitionIDParams) error {
+	_, err := q.db.ExecContext(ctx, deleteSeasonsByCompetitionID, arg.DeletedAt, arg.CompetitionID)
 	return err
 }
 

--- a/api/db/db_handler/mock/db.go
+++ b/api/db/db_handler/mock/db.go
@@ -309,6 +309,34 @@ func (mr *MockQueriesMockRecorder) DeleteGame(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGame", reflect.TypeOf((*MockQueries)(nil).DeleteGame), arg0, arg1)
 }
 
+// DeleteGamesByCompetitionID mocks base method.
+func (m *MockQueries) DeleteGamesByCompetitionID(arg0 context.Context, arg1 db.DeleteGamesByCompetitionIDParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteGamesByCompetitionID", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteGamesByCompetitionID indicates an expected call of DeleteGamesByCompetitionID.
+func (mr *MockQueriesMockRecorder) DeleteGamesByCompetitionID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGamesByCompetitionID", reflect.TypeOf((*MockQueries)(nil).DeleteGamesByCompetitionID), arg0, arg1)
+}
+
+// DeleteGamesBySeasonID mocks base method.
+func (m *MockQueries) DeleteGamesBySeasonID(arg0 context.Context, arg1 db.DeleteGamesBySeasonIDParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteGamesBySeasonID", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteGamesBySeasonID indicates an expected call of DeleteGamesBySeasonID.
+func (mr *MockQueriesMockRecorder) DeleteGamesBySeasonID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGamesBySeasonID", reflect.TypeOf((*MockQueries)(nil).DeleteGamesBySeasonID), arg0, arg1)
+}
+
 // DeleteSeason mocks base method.
 func (m *MockQueries) DeleteSeason(arg0 context.Context, arg1 db.DeleteSeasonParams) error {
 	m.ctrl.T.Helper()
@@ -335,6 +363,34 @@ func (m *MockQueries) DeleteSeasonTeam(arg0 context.Context, arg1 db.DeleteSeaso
 func (mr *MockQueriesMockRecorder) DeleteSeasonTeam(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSeasonTeam", reflect.TypeOf((*MockQueries)(nil).DeleteSeasonTeam), arg0, arg1)
+}
+
+// DeleteSeasonTeamsBySeasonID mocks base method.
+func (m *MockQueries) DeleteSeasonTeamsBySeasonID(arg0 context.Context, arg1 db.DeleteSeasonTeamsBySeasonIDParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSeasonTeamsBySeasonID", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSeasonTeamsBySeasonID indicates an expected call of DeleteSeasonTeamsBySeasonID.
+func (mr *MockQueriesMockRecorder) DeleteSeasonTeamsBySeasonID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSeasonTeamsBySeasonID", reflect.TypeOf((*MockQueries)(nil).DeleteSeasonTeamsBySeasonID), arg0, arg1)
+}
+
+// DeleteSeasonsByCompetitionID mocks base method.
+func (m *MockQueries) DeleteSeasonsByCompetitionID(arg0 context.Context, arg1 db.DeleteSeasonsByCompetitionIDParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSeasonsByCompetitionID", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSeasonsByCompetitionID indicates an expected call of DeleteSeasonsByCompetitionID.
+func (mr *MockQueriesMockRecorder) DeleteSeasonsByCompetitionID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSeasonsByCompetitionID", reflect.TypeOf((*MockQueries)(nil).DeleteSeasonsByCompetitionID), arg0, arg1)
 }
 
 // DeleteTeam mocks base method.

--- a/api/db/db_handler/queries.go
+++ b/api/db/db_handler/queries.go
@@ -86,6 +86,14 @@ func DeleteSeason(
 	return q.DeleteSeason(ctx, params)
 }
 
+func DeleteSeasonsByCompetitionID(
+	ctx context.Context,
+	q Queries,
+	params db.DeleteSeasonsByCompetitionIDParams,
+) error {
+	return q.DeleteSeasonsByCompetitionID(ctx, params)
+}
+
 func CreateTeam(
 	ctx context.Context,
 	q Queries,
@@ -147,4 +155,68 @@ func DeleteSeasonTeam(
 	params db.DeleteSeasonTeamParams,
 ) error {
 	return q.DeleteSeasonTeam(ctx, params)
+}
+
+func DeleteSeasonTeamsBySeasonID(
+	ctx context.Context,
+	q Queries,
+	params db.DeleteSeasonTeamsBySeasonIDParams,
+) error {
+	return q.DeleteSeasonTeamsBySeasonID(ctx, params)
+}
+
+func CreateGame(
+	ctx context.Context,
+	q Queries,
+	params db.CreateGameParams,
+) error {
+	return q.CreateGame(ctx, params)
+}
+
+func GetGame(
+	ctx context.Context,
+	q Queries,
+	id uuid.UUID,
+) (db.Game, error) {
+	return q.GetGame(ctx, id)
+}
+
+func GetGames(
+	ctx context.Context,
+	q Queries,
+	seasonID uuid.UUID,
+) ([]db.Game, error) {
+	return q.GetGames(ctx, seasonID)
+}
+
+func UpdateGame(
+	ctx context.Context,
+	q Queries,
+	params db.UpdateGameParams,
+) error {
+	return q.UpdateGame(ctx, params)
+}
+
+func DeleteGame(
+	ctx context.Context,
+	q Queries,
+	params db.DeleteGameParams,
+) error {
+	return q.DeleteGame(ctx, params)
+}
+
+func DeleteGamesByCompetitionID(
+	ctx context.Context,
+	q Queries,
+	params db.DeleteGamesByCompetitionIDParams,
+) error {
+	return q.DeleteGamesByCompetitionID(ctx, params)
+}
+
+func DeleteGamesBySeasonID(
+	ctx context.Context,
+	q Queries,
+	params db.DeleteGamesBySeasonIDParams,
+) error {
+	return q.DeleteGamesBySeasonID(ctx, params)
 }

--- a/api/db/db_handler/wrapper.go
+++ b/api/db/db_handler/wrapper.go
@@ -35,6 +35,7 @@ type Queries interface {
 	GetSeasons(ctx context.Context, competitionID uuid.UUID) ([]db.Season, error)
 	UpdateSeason(ctx context.Context, arg db.UpdateSeasonParams) error
 	DeleteSeason(ctx context.Context, arg db.DeleteSeasonParams) error
+	DeleteSeasonsByCompetitionID(ctx context.Context, arg db.DeleteSeasonsByCompetitionIDParams) error
 
 	//Team
 	CreateTeam(ctx context.Context, arg db.CreateTeamParams) error
@@ -47,6 +48,7 @@ type Queries interface {
 	CreateSeasonTeams(ctx context.Context, arg db.CreateSeasonTeamsParams) error
 	GetSeasonTeams(ctx context.Context, seasonID uuid.UUID) ([]db.GetSeasonTeamsRow, error)
 	DeleteSeasonTeam(ctx context.Context, arg db.DeleteSeasonTeamParams) error
+	DeleteSeasonTeamsBySeasonID(ctx context.Context, arg db.DeleteSeasonTeamsBySeasonIDParams) error
 
 	//Game
 	CreateGame(ctx context.Context, arg db.CreateGameParams) error
@@ -54,6 +56,8 @@ type Queries interface {
 	GetGames(ctx context.Context, seasonID uuid.UUID) ([]db.Game, error)
 	UpdateGame(ctx context.Context, arg db.UpdateGameParams) error
 	DeleteGame(ctx context.Context, arg db.DeleteGameParams) error
+	DeleteGamesByCompetitionID(ctx context.Context, arg db.DeleteGamesByCompetitionIDParams) error
+	DeleteGamesBySeasonID(ctx context.Context, arg db.DeleteGamesBySeasonIDParams) error
 }
 
 type DBWrapper struct {

--- a/api/query.sql
+++ b/api/query.sql
@@ -146,6 +146,16 @@ WHERE
 AND
 	deleted_at IS NULL;
 
+-- name: DeleteSeasonsByCompetitionID :exec
+-- Soft delete all seasons for a competition
+UPDATE seasons
+SET
+    deleted_at = @deleted_at
+WHERE
+    competition_id = @competition_id
+AND
+    deleted_at IS NULL;
+
 -- name: CreateTeam :exec
 -- Insert a new team into the database
 INSERT INTO teams (
@@ -267,6 +277,16 @@ WHERE
 AND
   deleted_at IS NULL;
 
+-- name: DeleteSeasonTeamsBySeasonID :exec
+-- Soft delete all team_season records for a given season
+UPDATE season_teams
+SET
+  deleted_at = @deleted_at
+WHERE
+  season_id = @season_id
+AND
+  deleted_at IS NULL;
+
 -- name: CreateGame :exec
 -- Insert a new game into the database
 INSERT INTO games (
@@ -368,3 +388,28 @@ WHERE
     id = @id
 AND
     deleted_at IS NULL;
+
+-- name: DeleteGamesByCompetitionID :exec
+-- Soft delete all games belonging to a competition via seasons
+UPDATE games
+SET
+    deleted_at = @deleted_at
+WHERE
+    season_id IN (
+        SELECT id
+        FROM seasons
+        WHERE competition_id = @competition_id
+          AND deleted_at IS NULL
+    )
+AND
+    deleted_at IS NULL;
+
+-- name: DeleteGamesBySeasonID :exec
+-- Soft delete all games for a given season
+UPDATE games
+SET
+  deleted_at = @deleted_at
+WHERE
+  season_id = @season_id
+AND
+  deleted_at IS NULL;

--- a/api/service/competition.go
+++ b/api/service/competition.go
@@ -160,12 +160,34 @@ func deleteCompetition(
 	queries db_handler.Queries,
 	competitionID uuid.UUID,
 ) error {
+	now := time.Now()
+
+	deleteGamesByCompetitionIDParams := db.DeleteGamesByCompetitionIDParams{
+		DeletedAt:     sql.NullTime{Time: now, Valid: true},
+		CompetitionID: competitionID,
+	}
+
+	err := queries.DeleteGamesByCompetitionID(ctx, deleteGamesByCompetitionIDParams)
+	if err != nil {
+		return errors.Wrap(err, "unable to delete games for competition")
+	}
+
+	deleteSeasonsByCompetitionIDParams := db.DeleteSeasonsByCompetitionIDParams{
+		DeletedAt:     sql.NullTime{Time: now, Valid: true},
+		CompetitionID: competitionID,
+	}
+
+	err = queries.DeleteSeasonsByCompetitionID(ctx, deleteSeasonsByCompetitionIDParams)
+	if err != nil {
+		return errors.Wrap(err, "unable to delete seasons for competition")
+	}
+
 	deleteCompetitionParams := db.DeleteCompetitionParams{
-		DeletedAt: sql.NullTime{Time: time.Now(), Valid: true},
+		DeletedAt: sql.NullTime{Time: now, Valid: true},
 		ID:        competitionID,
 	}
 
-	err := queries.DeleteCompetition(ctx, deleteCompetitionParams)
+	err = queries.DeleteCompetition(ctx, deleteCompetitionParams)
 	if err != nil {
 		return errors.Wrap(err, "unable to delete competition")
 	}

--- a/api/service/competition_test.go
+++ b/api/service/competition_test.go
@@ -419,6 +419,15 @@ var _ = Describe("competition", func() {
 			mockDB.EXPECT().New(
 				gomock.Any(),
 			).Return(mockQueries)
+			mockQueries.EXPECT().DeleteGamesByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+
+			mockQueries.EXPECT().DeleteSeasonsByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().DeleteCompetition(
 				gomock.Any(),
 				gomock.Any(),
@@ -448,6 +457,50 @@ var _ = Describe("competition", func() {
 			Expect(err.Error()).To(Equal(validTestError.Error()))
 		})
 
+		It("should rollback and return error if deleting games fails", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().DeleteGamesByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).AnyTimes()
+
+			err := DeleteCompetition(context.Background(), mockDB, validCompetitionID)
+			Expect(err.Error()).To(Equal("unable to delete games for competition: a valid testing error"))
+		})
+
+		It("should rollback and return error if deleting seasons fails", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().DeleteGamesByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonsByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).AnyTimes()
+
+			err := DeleteCompetition(context.Background(), mockDB, validCompetitionID)
+			Expect(err.Error()).To(Equal("unable to delete seasons for competition: a valid testing error"))
+		})
+
 		It("should rollback and return formatted error on delete failure", func() {
 			mockDB.EXPECT().BeginTx(
 				gomock.Any(),
@@ -456,6 +509,14 @@ var _ = Describe("competition", func() {
 			mockDB.EXPECT().New(
 				gomock.Any(),
 			).Return(mockQueries)
+			mockQueries.EXPECT().DeleteGamesByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonsByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().DeleteCompetition(
 				gomock.Any(),
 				gomock.Any(),
@@ -477,6 +538,14 @@ var _ = Describe("competition", func() {
 			mockDB.EXPECT().New(
 				gomock.Any(),
 			).Return(mockQueries)
+			mockQueries.EXPECT().DeleteGamesByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonsByCompetitionID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
 			mockQueries.EXPECT().DeleteCompetition(
 				gomock.Any(),
 				gomock.Any(),

--- a/api/service/season_test.go
+++ b/api/service/season_test.go
@@ -49,7 +49,7 @@ var _ = Describe("season", func() {
 		StartDate: validTimeNow,
 		EndDate:   validTimeNow.AddDate(0, 5, 0),
 		Rounds:    15,
-		Teams:   validTeamIDs,
+		Teams:     validTeamIDs,
 	}
 
 	var validNilSeason db.Season
@@ -1170,15 +1170,11 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
-			mockQueries.EXPECT().GetSeasonTeams(
-				gomock.Any(),
-				gomock.Any(),
-			).Return(validSeasonTeamsFromDB, nil)
-			mockQueries.EXPECT().DeleteSeasonTeam(
+			mockQueries.EXPECT().DeleteGamesBySeasonID(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
-			mockQueries.EXPECT().DeleteSeasonTeam(
+			mockQueries.EXPECT().DeleteSeasonTeamsBySeasonID(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
@@ -1233,7 +1229,7 @@ var _ = Describe("season", func() {
 			Expect(err.Error()).To(Equal("failed deleting season: unable to get season for deletion: a valid testing error"))
 		})
 
-		It("should rollback and return a formatted error when getting season teams fails", func() {
+		It("should rollback and return a formatted error when deleting games fails", func() {
 			mockDB.EXPECT().BeginTx(
 				gomock.Any(),
 				gomock.Any(),
@@ -1245,36 +1241,7 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
-			mockQueries.EXPECT().GetSeasonTeams(
-				gomock.Any(),
-				gomock.Any(),
-			).Return(nil, validTestError)
-			mockDB.EXPECT().Rollback(
-				gomock.Any(),
-			).Times(1)
-
-			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
-
-			Expect(err.Error()).To(Equal("failed deleting season: unable to get season teams for deletion: a valid testing error"))
-		})
-
-		It("should rollback and return a formatted error when deleting a season team fails", func() {
-			mockDB.EXPECT().BeginTx(
-				gomock.Any(),
-				gomock.Any(),
-			)
-			mockDB.EXPECT().New(
-				gomock.Any(),
-			).Return(mockQueries)
-			mockQueries.EXPECT().GetSeason(
-				gomock.Any(),
-				gomock.Any(),
-			).Return(validSeasonFromDB, nil)
-			mockQueries.EXPECT().GetSeasonTeams(
-				gomock.Any(),
-				gomock.Any(),
-			).Return(validSeasonTeamsFromDB, nil)
-			mockQueries.EXPECT().DeleteSeasonTeam(
+			mockQueries.EXPECT().DeleteGamesBySeasonID(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validTestError)
@@ -1283,8 +1250,35 @@ var _ = Describe("season", func() {
 			).Times(1)
 
 			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+			Expect(err.Error()).To(Equal("failed deleting season: unable to delete games for season: a valid testing error"))
+		})
 
-			Expect(err.Error()).To(Equal("failed deleting season: unable to remove team 11111111-1111-4111-8111-111111111111 from season aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa: a valid testing error"))
+		It("should rollback and return a formatted error when deleting season teams fails", func() {
+			mockDB.EXPECT().BeginTx(
+				gomock.Any(),
+				gomock.Any(),
+			)
+			mockDB.EXPECT().New(
+				gomock.Any(),
+			).Return(mockQueries)
+			mockQueries.EXPECT().GetSeason(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validSeasonFromDB, nil)
+			mockQueries.EXPECT().DeleteGamesBySeasonID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(nil)
+			mockQueries.EXPECT().DeleteSeasonTeamsBySeasonID(
+				gomock.Any(),
+				gomock.Any(),
+			).Return(validTestError)
+			mockDB.EXPECT().Rollback(
+				gomock.Any(),
+			).Times(1)
+
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+			Expect(err.Error()).To(Equal("failed deleting season: unable to delete season teams for season: a valid testing error"))
 		})
 
 		It("should rollback and return a formatted error when deleting the season fails", func() {
@@ -1299,15 +1293,11 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
-			mockQueries.EXPECT().GetSeasonTeams(
-				gomock.Any(),
-				gomock.Any(),
-			).Return(validSeasonTeamsFromDB, nil)
-			mockQueries.EXPECT().DeleteSeasonTeam(
+			mockQueries.EXPECT().DeleteGamesBySeasonID(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
-			mockQueries.EXPECT().DeleteSeasonTeam(
+			mockQueries.EXPECT().DeleteSeasonTeamsBySeasonID(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
@@ -1336,15 +1326,11 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 				gomock.Any(),
 			).Return(validSeasonFromDB, nil)
-			mockQueries.EXPECT().GetSeasonTeams(
-				gomock.Any(),
-				gomock.Any(),
-			).Return(validSeasonTeamsFromDB, nil)
-			mockQueries.EXPECT().DeleteSeasonTeam(
+			mockQueries.EXPECT().DeleteGamesBySeasonID(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)
-			mockQueries.EXPECT().DeleteSeasonTeam(
+			mockQueries.EXPECT().DeleteSeasonTeamsBySeasonID(
 				gomock.Any(),
 				gomock.Any(),
 			).Return(nil)


### PR DESCRIPTION
Adding app level cascading deletes. 

- When soft deleting comp it deletes comps seasons and comps games.
- When soft deleting seasons it deletes seasons teams links and seasons games.