### PR TITLE
Gainline API - Glakey tests and delete season param.

### DIFF
--- a/api/http/handlers/season.go
+++ b/api/http/handlers/season.go
@@ -190,19 +190,13 @@ func handleUpdateSeason(logger zerolog.Logger, db db_handler.DB) gin.HandlerFunc
 //	@Router		/competitions/{competitionID}/seasons/{seasonID} [delete]
 func handleDeleteSeason(logger zerolog.Logger, db db_handler.DB) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		competitionID, err := uuid.Parse(ctx.Param("competitionID"))
-		if err != nil {
-			response.RespondError(ctx, logger, err, http.StatusBadRequest, "Invalid competition ID")
-			return
-		}
-
 		seasonID, err := uuid.Parse(ctx.Param("seasonID"))
 		if err != nil {
 			response.RespondError(ctx, logger, err, http.StatusBadRequest, "Invalid season ID")
 			return
 		}
 
-		err = service.DeleteSeason(ctx, db, competitionID, seasonID)
+		err = service.DeleteSeason(ctx, db, seasonID)
 		if err != nil {
 			response.RespondError(ctx, logger, err, http.StatusInternalServerError, "Unable to delete season")
 			return

--- a/api/service/season.go
+++ b/api/service/season.go
@@ -425,11 +425,10 @@ func removeExtraSeasonTeams(
 func DeleteSeason(
 	ctx context.Context,
 	dbHandler db_handler.DB,
-	competitionID uuid.UUID,
 	seasonID uuid.UUID,
 ) error {
 	err := db_handler.RunInTransaction(ctx, dbHandler, func(queries db_handler.Queries) error {
-		return deleteSeason(ctx, queries, competitionID, seasonID)
+		return deleteSeason(ctx, queries, seasonID)
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed deleting season")
@@ -441,7 +440,6 @@ func DeleteSeason(
 func deleteSeason(
 	ctx context.Context,
 	queries db_handler.Queries,
-	competitionID uuid.UUID,
 	seasonID uuid.UUID,
 ) error {
 	now := time.Now()

--- a/api/service/season_test.go
+++ b/api/service/season_test.go
@@ -707,11 +707,11 @@ var _ = Describe("season", func() {
 			).Return(nil)
 			mockQueries.EXPECT().GetTeam(
 				gomock.Any(),
-				gomock.Any(),
+				validTeamID,
 			).Return(validTeamFromDB, nil)
 			mockQueries.EXPECT().GetTeam(
 				gomock.Any(),
-				gomock.Any(),
+				validTeamID2,
 			).Return(db.Team{}, validTestError)
 			mockDB.EXPECT().Rollback(
 				gomock.Any(),
@@ -1084,7 +1084,7 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 			).Times(0)
 
-			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID)
 
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -1098,7 +1098,7 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 			).Times(0)
 
-			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID)
 
 			Expect(err.Error()).To(Equal("failed deleting season: a valid testing error"))
 		})
@@ -1119,7 +1119,7 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 			).Times(1)
 
-			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID)
 			Expect(err.Error()).To(Equal("failed deleting season: unable to delete games for season: a valid testing error"))
 		})
 
@@ -1143,7 +1143,7 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 			).Times(1)
 
-			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID)
 			Expect(err.Error()).To(Equal("failed deleting season: unable to delete season teams for season: a valid testing error"))
 		})
 
@@ -1171,7 +1171,7 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 			).Times(1)
 
-			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID)
 
 			Expect(err.Error()).To(Equal("failed deleting season: unable to delete season: a valid testing error"))
 		})
@@ -1203,7 +1203,7 @@ var _ = Describe("season", func() {
 				gomock.Any(),
 			).Times(0)
 
-			err := DeleteSeason(context.Background(), mockDB, validCompetitionID, validSeasonID)
+			err := DeleteSeason(context.Background(), mockDB, validCompetitionID)
 
 			Expect(err.Error()).To(Equal("failed deleting season: a valid testing error"))
 		})


### PR DESCRIPTION
The UpdateSeason getTeam error test was s bit flaky so tidied that up.

The DeleteSeason service had a extra competitionID param which is not needed now.