### PR TITLE
Gainline API - Update get season endpoint to use context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ docker volume rm gainline-data
 ```
 
 ## Todo:
-
 - Implement search across core entities (teams, games, seasons, competitions).
 - Add pagination to API responses and frontend tables.
 - Write a full migration seeder (seasons, teams, games, scores).

--- a/api/README.md
+++ b/api/README.md
@@ -43,7 +43,6 @@ mockgen -destination=/home/bradley/Personal/gainline/api/db/db_handler/mock/db.g
 ```
 
 ## Todo:
-- Service level validation tests for games.
 - Service level validation for Seasons.
 - Middleware to enforce ownership (e.g., only owners/admins can edit/delete).
 - Request validation layer (schema validation for all endpoints).

--- a/api/http/handlers/season.go
+++ b/api/http/handlers/season.go
@@ -109,23 +109,7 @@ func handleGetSeasons(logger zerolog.Logger, db db_handler.DB) gin.HandlerFunc {
 //	@Router		/competitions/{competitionID}/seasons/{seasonID} [get]
 func handleGetSeason(logger zerolog.Logger, db db_handler.DB) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		competitionID, err := uuid.Parse(ctx.Param("competitionID"))
-		if err != nil {
-			response.RespondError(ctx, logger, err, http.StatusBadRequest, "Invalid competition ID")
-			return
-		}
-
-		seasonID, err := uuid.Parse(ctx.Param("seasonID"))
-		if err != nil {
-			response.RespondError(ctx, logger, err, http.StatusBadRequest, "Invalid season ID")
-			return
-		}
-
-		season, err := service.GetSeason(ctx.Request.Context(), db, competitionID, seasonID)
-		if err != nil {
-			response.RespondError(ctx, logger, err, http.StatusInternalServerError, "Unable to get season")
-			return
-		}
+		season := ctx.MustGet("season").(service.SeasonWithTeams)
 
 		response.RespondSuccess(ctx, logger, http.StatusOK, service.ToSeasonResponse(season))
 	}


### PR DESCRIPTION
Calling get season in the middleware and saving to context for validations. No point calling the get season in service again after that.