### PR TITLE
Gainline API - Moving from per-method DB injection to a service-level DB binding

### DIFF
--- a/api/http/handlers/competition.go
+++ b/api/http/handlers/competition.go
@@ -28,7 +28,6 @@ import (
 //	@Router		/competitions [post]
 func handleCreateCompetition(
 	logger zerolog.Logger,
-	db db_handler.DB,
 	validate *validator.Validate,
 	svc service.CompetitionService,
 ) gin.HandlerFunc {
@@ -47,7 +46,7 @@ func handleCreateCompetition(
 			return
 		}
 
-		competition, err := svc.Create(ctx.Request.Context(), db, req)
+		competition, err := svc.Create(ctx.Request.Context(), req)
 		if err != nil {
 			response.RespondError(ctx, logger, err, http.StatusInternalServerError, "Unable to add competition")
 			return

--- a/api/http/handlers/competition_test.go
+++ b/api/http/handlers/competition_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/bradley-adams/gainline/db/db"
-	"github.com/bradley-adams/gainline/db/db_handler"
 	"github.com/bradley-adams/gainline/http/api"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
@@ -18,29 +17,29 @@ import (
 
 // Manual mock for CompetitionService
 type mockCompetitionService struct {
-	CreateFn func(ctx context.Context, dbHandlerDB db_handler.DB, req *api.CompetitionRequest) (db.Competition, error)
+	CreateFn func(ctx context.Context, req *api.CompetitionRequest) (db.Competition, error)
 }
 
-func (m *mockCompetitionService) Create(ctx context.Context, dbHandlerDB db_handler.DB, req *api.CompetitionRequest) (db.Competition, error) {
+func (m *mockCompetitionService) Create(ctx context.Context, req *api.CompetitionRequest) (db.Competition, error) {
 	if m.CreateFn != nil {
-		return m.CreateFn(ctx, dbHandlerDB, req)
+		return m.CreateFn(ctx, req)
 	}
 	return db.Competition{}, nil
 }
 
-func (m *mockCompetitionService) GetAll(ctx context.Context, dbHandlerDB db_handler.DB) ([]db.Competition, error) {
+func (m *mockCompetitionService) GetAll(ctx context.Context) ([]db.Competition, error) {
 	return nil, nil
 }
 
-func (m *mockCompetitionService) Get(ctx context.Context, dbHandlerDB db_handler.DB, id uuid.UUID) (db.Competition, error) {
+func (m *mockCompetitionService) Get(ctx context.Context, id uuid.UUID) (db.Competition, error) {
 	return db.Competition{}, nil
 }
 
-func (m *mockCompetitionService) Update(ctx context.Context, dbHandlerDB db_handler.DB, id uuid.UUID, req *api.CompetitionRequest) (db.Competition, error) {
+func (m *mockCompetitionService) Update(ctx context.Context, id uuid.UUID, req *api.CompetitionRequest) (db.Competition, error) {
 	return db.Competition{}, nil
 }
 
-func (m *mockCompetitionService) Delete(ctx context.Context, dbHandlerDB db_handler.DB, id uuid.UUID) error {
+func (m *mockCompetitionService) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
@@ -57,7 +56,7 @@ func TestHandleCreateCompetition(t *testing.T) {
 
 	// Manual mock service
 	mockSvc := &mockCompetitionService{
-		CreateFn: func(ctx context.Context, dbHandlerDB db_handler.DB, req *api.CompetitionRequest) (db.Competition, error) {
+		CreateFn: func(ctx context.Context, req *api.CompetitionRequest) (db.Competition, error) {
 			return db.Competition{
 				ID:   uuid.New(),
 				Name: req.Name,
@@ -67,7 +66,7 @@ func TestHandleCreateCompetition(t *testing.T) {
 
 	// Setup Gin router with the handler
 	router := gin.New()
-	router.POST("/competitions", handleCreateCompetition(logger, nil, validate, mockSvc))
+	router.POST("/competitions", handleCreateCompetition(logger, validate, mockSvc))
 
 	// Prepare a valid JSON request
 	reqBody := `{"name":"Test Competition"}`

--- a/api/http/handlers/http.go
+++ b/api/http/handlers/http.go
@@ -36,8 +36,8 @@ func SetupRouter(db db_handler.DB, logger zerolog.Logger, validate *validator.Va
 		v1public.Use(middleware.CompetitionStructureValidator(logger, db))
 
 		// competitions
-		svc := service.DefaultCompetitionService{}
-		v1public.POST("/competitions", handleCreateCompetition(logger, db, validate, svc))
+		svc := service.NewCompetitionService(db)
+		v1public.POST("/competitions", handleCreateCompetition(logger, validate, svc))
 		v1public.GET("/competitions", handleGetCompetitions(logger, db))
 		v1public.GET("/competitions/:competitionID", handleGetCompetition(logger, db))
 		v1public.PUT("/competitions/:competitionID", handleUpdateCompetition(logger, db, validate))

--- a/api/service/competition.go
+++ b/api/service/competition.go
@@ -14,11 +14,11 @@ import (
 )
 
 type CompetitionService interface {
-	Create(ctx context.Context, db db_handler.DB, req *api.CompetitionRequest) (db.Competition, error)
-	GetAll(ctx context.Context, db db_handler.DB) ([]db.Competition, error)
-	Get(ctx context.Context, db db_handler.DB, id uuid.UUID) (db.Competition, error)
-	Update(ctx context.Context, db db_handler.DB, id uuid.UUID, req *api.CompetitionRequest) (db.Competition, error)
-	Delete(ctx context.Context, db db_handler.DB, id uuid.UUID) error
+	Create(ctx context.Context, req *api.CompetitionRequest) (db.Competition, error)
+	GetAll(ctx context.Context) ([]db.Competition, error)
+	Get(ctx context.Context, id uuid.UUID) (db.Competition, error)
+	Update(ctx context.Context, id uuid.UUID, req *api.CompetitionRequest) (db.Competition, error)
+	Delete(ctx context.Context, id uuid.UUID) error
 }
 
 func CreateCompetition(

--- a/api/service/competitionwrapper.go
+++ b/api/service/competitionwrapper.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	"github.com/bradley-adams/gainline/db/db"
 	"github.com/bradley-adams/gainline/db/db_handler"
@@ -9,25 +10,42 @@ import (
 	"github.com/google/uuid"
 )
 
-// DefaultCompetitionService wraps the existing functions to implement CompetitionService interface
-type DefaultCompetitionService struct{}
-
-func (s DefaultCompetitionService) Create(ctx context.Context, db db_handler.DB, req *api.CompetitionRequest) (db.Competition, error) {
-	return CreateCompetition(ctx, db, req)
+type DefaultCompetitionService struct {
+	db db_handler.DB
 }
 
-func (s DefaultCompetitionService) GetAll(ctx context.Context, db db_handler.DB) ([]db.Competition, error) {
-	return GetCompetitions(ctx, db)
+func NewCompetitionService(db db_handler.DB) CompetitionService {
+	return &DefaultCompetitionService{db: db}
 }
 
-func (s DefaultCompetitionService) Get(ctx context.Context, db db_handler.DB, id uuid.UUID) (db.Competition, error) {
-	return GetCompetition(ctx, db, id)
+func (s *DefaultCompetitionService) Create(ctx context.Context, req *api.CompetitionRequest) (db.Competition, error) {
+	req.Name = strings.TrimSpace(req.Name)
+
+	var competition db.Competition
+	err := db_handler.RunInTransaction(ctx, s.db, func(queries db_handler.Queries) error {
+		var err error
+		competition, err = createCompetition(ctx, queries, req)
+		return err
+	})
+	if err != nil {
+		return db.Competition{}, err
+	}
+
+	return competition, nil
 }
 
-func (s DefaultCompetitionService) Update(ctx context.Context, db db_handler.DB, id uuid.UUID, req *api.CompetitionRequest) (db.Competition, error) {
-	return UpdateCompetition(ctx, db, id, req)
+func (s *DefaultCompetitionService) GetAll(ctx context.Context) ([]db.Competition, error) {
+	return GetCompetitions(ctx, s.db)
 }
 
-func (s DefaultCompetitionService) Delete(ctx context.Context, db db_handler.DB, id uuid.UUID) error {
-	return DeleteCompetition(ctx, db, id)
+func (s *DefaultCompetitionService) Get(ctx context.Context, id uuid.UUID) (db.Competition, error) {
+	return GetCompetition(ctx, s.db, id)
+}
+
+func (s *DefaultCompetitionService) Update(ctx context.Context, id uuid.UUID, req *api.CompetitionRequest) (db.Competition, error) {
+	return UpdateCompetition(ctx, s.db, id, req)
+}
+
+func (s *DefaultCompetitionService) Delete(ctx context.Context, id uuid.UUID) error {
+	return DeleteCompetition(ctx, s.db, id)
 }


### PR DESCRIPTION
Drop the db_handler.DB parameter from each method and instead pass it once when creating the service.