### PR TITLE
Gainline API - Adding all create handler tests

### DIFF
--- a/api/http/handlers/handler_test.go
+++ b/api/http/handlers/handler_test.go
@@ -1,0 +1,13 @@
+package handlers
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "handler Suite")
+}


### PR DESCRIPTION
Covering all success/failure cases in the competition handler create.