### PR TITLE
fixing some param order mistake

### DIFF
--- a/api/http/middleware/middleware.go
+++ b/api/http/middleware/middleware.go
@@ -78,7 +78,7 @@ func validateGame(ctx context.Context, gameID, seasonID uuid.UUID, gameService s
 }
 
 func validateSeason(ctx *gin.Context, seasonID, competitionID uuid.UUID, seasonService service.SeasonService) error {
-	season, err := seasonService.Get(ctx.Request.Context(), seasonID, competitionID)
+	season, err := seasonService.Get(ctx.Request.Context(), competitionID, seasonID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
These params were the wrong way around. Probably from the recent refactor and I missed it being incorrect.